### PR TITLE
Require chef version in which chef/resource_resolver is present

### DIFF
--- a/chef-lxc.gemspec
+++ b/chef-lxc.gemspec
@@ -19,7 +19,7 @@ Gem::Specification.new do |spec|
   spec.require_paths = ["lib"]
   spec.bindir        = "bin"
 
-  spec.add_dependency "chef", ">= 12"
+  spec.add_dependency "chef", ">= 12.3"
   spec.add_dependency "ruby-lxc"
   spec.add_dependency "lxc-extra"
   spec.homepage    = 'https://github.com/ranjib/chef-lxc'


### PR DESCRIPTION
chef/resource_resolver is required in lib/chef/lxc_helper.
It was added in https://github.com/chef/chef/commit/e3a6565927e854cd5968bd3a6bd2248ec1245549, which is only
in chef starting at v 12.3.