### PR TITLE
Fix of container configuration setup and network startup

### DIFF
--- a/lib/chef/provider/lxc.rb
+++ b/lib/chef/provider/lxc.rb
@@ -43,7 +43,12 @@ class Chef
       def update_config
         updated_items = []
         new_resource.config.each do |key, expected_value|
-          if ct.config_item(key) != expected_value
+          begin
+            if ct.config_item(key) != expected_value
+              ct.set_config_item(key, expected_value)
+              updated_items << key
+            end
+          rescue ::LXC::Error => e
             ct.set_config_item(key, expected_value)
             updated_items << key
           end

--- a/lib/chef/provider/lxc.rb
+++ b/lib/chef/provider/lxc.rb
@@ -77,8 +77,8 @@ class Chef
           converge_by("start container '#{ct.name}'") do
             ct.start
             if new_resource.wait_for_network
-              until ct.ip_addresses.empty?
-                Chef::Log.debug('waiting for ip allocation')
+              while ct.ip_addresses.empty?
+                Chef::Log.error('waiting for ip allocation')
                 sleep 1
               end
             end

--- a/lib/chef/provider/lxc.rb
+++ b/lib/chef/provider/lxc.rb
@@ -1,4 +1,5 @@
 require 'chef/lxc_helper'
+require 'timeout'
 
 class Chef
   class Provider
@@ -77,18 +78,21 @@ class Chef
           converge_by("start container '#{ct.name}'") do
             ct.start
             if new_resource.wait_for_network
-              (1..10).each do
-                break unless ct.ip_addresses.empty?
-                Chef::Log.warn('waiting for ip allocation')
-                sleep 1
-              end
-              if (ct.ip_addresses.empty?)
-                Chef::Log.error('container network not coming up')
-                raise 'container network not coming up'
+              begin
+                Timeout::timeout(10) {
+                  while ct.ip_addresses.empty?
+                     Chef::Log.warn('waiting for ip allocation')
+                     sleep 1
+                  end
+                }
+              rescue Timeout::Error
+                  Chef::Log.error('container network not coming up')
+                  raise 'container network not coming up'
               end
             end
           end
         end
+
         unless new_resource.recipe_block.nil?
           recipe_in_container(ct, &new_resource.recipe_block)
         end

--- a/lib/chef/provider/lxc.rb
+++ b/lib/chef/provider/lxc.rb
@@ -77,9 +77,14 @@ class Chef
           converge_by("start container '#{ct.name}'") do
             ct.start
             if new_resource.wait_for_network
-              while ct.ip_addresses.empty?
-                Chef::Log.error('waiting for ip allocation')
+              (1..10).each do
+                break unless ct.ip_addresses.empty?
+                Chef::Log.warn('waiting for ip allocation')
                 sleep 1
+              end
+              if (ct.ip_addresses.empty?)
+                Chef::Log.error('container network not coming up')
+                raise 'container network not coming up'
               end
             end
           end


### PR DESCRIPTION
Hi Ranjib,

I just fixed two issues:
- When setting some previously unknown network settings (e.g. lxc.network.ipv4 when the default
  configuration is empty) the chef run crashed because of an unhandled exception.
- When starting up a container with a broken network configuration, the chef run waited forever. It now waits for max. 10 seconds, then stops.

I'd like you to merge these fixes into your repository.
 Kind regards,
   Marcus
